### PR TITLE
Updating folder permissions for new Gatling plugin

### DIFF
--- a/11/Dockerfile
+++ b/11/Dockerfile
@@ -9,5 +9,6 @@ RUN wget -O /tmp/gatling-charts-highcharts-bundle-$VERSION-bundle.zip \
     https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$VERSION/gatling-charts-highcharts-bundle-$VERSION-bundle.zip \
   && unzip /tmp/gatling-charts-highcharts-bundle-$VERSION-bundle.zip -d /etc \
   && mv /etc/gatling-charts-highcharts-bundle-$VERSION /etc/gatling \
+  && chmod a+w /etc/gatling \
   && chmod +x /etc/gatling/bin/gatling.sh /etc/gatling/bin/recorder.sh \
   && rm /tmp/gatling-charts-highcharts-bundle-$VERSION-bundle.zip


### PR DESCRIPTION
**Before creating a pull request make sure that:**

### JIRA link (if applicable) ###

N/A (but supports https://tools.hmcts.net/jira/browse/RDO-10404)

### Change description ###

Migrating from com.github.lkishalmi.gatling (deprecated) to io.gatling.gradle (new, officially supported) Gatling plugin, which is complaining about permissions to the /etc/gatling folder. This PR addresses that.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
